### PR TITLE
Throw exception in AuthenticationService if it fails to retrieve token

### DIFF
--- a/ClientCredentialsKeypairs/AuthenticationService.cs
+++ b/ClientCredentialsKeypairs/AuthenticationService.cs
@@ -42,6 +42,10 @@ public class AuthenticationService : IAuthenticationService
             }
         };
         var response = await c.RequestClientCredentialsTokenAsync(cctr);
+        if (response.IsError)
+        {
+            throw new Exception($"Unable to get access token: {response.Error}");
+        }
         AccessToken = response.AccessToken;
     }
 


### PR DESCRIPTION
AuthenticationService will fail silently if it fails to retrieve a token. Some kind of logging or exception is needed to make the user aware of the error.