### PR TITLE
Refit: Dont use header propagatin

### DIFF
--- a/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
+++ b/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
@@ -1,16 +1,30 @@
-﻿namespace Fhi.ClientCredentials.Refit;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Fhi.ClientCredentials.Refit;
 
 public class CorrelationIdHandler : DelegatingHandler
 {
     public const string CorrelationIdHeaderName = "X-Correlation-ID";
+    private readonly IHttpContextAccessor httpContextAccessor;
 
-    public CorrelationIdHandler()
+    public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor)
     {
+        this.httpContextAccessor = httpContextAccessor;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var correalationId = Guid.NewGuid().ToString();
+
+        var context = httpContextAccessor.HttpContext;
+        if (context != null)
+        {
+            var corrFromContext = context.Request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHeaderName).Value.FirstOrDefault();
+            if (corrFromContext != null)
+            {
+                correalationId = corrFromContext;
+            }
+        }
 
         if (request.Headers.TryGetValues(CorrelationIdHeaderName, out var values))
         {

--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>1.0.0-beta.4</Version>
+		<Version>1.0.0-beta.5</Version>
 		<authors>Folkehelseinstituttet (FHI)</authors>
 		<Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -69,10 +69,12 @@ namespace Fhi.ClientCredentialsKeypairs.Refit
                     httpClient.BaseAddress = clientCredentialsConfig.UriToApiByName(nameOfService ?? typeof(T).Name);
                 });
 
+            /* // we can't  add header propagation to without a httpcontext
             if (options.UseCorrelationId)
             {
                 clientBuilder.AddHeaderPropagation();
             }
+            */
 
             foreach (var type in DelegationHandlers)
             {


### PR DESCRIPTION
Header propagation does not work without a http request to get headers from. The refit client is a "singleton", so it does not support the propagation. Added temporary code to the midleware to try to grab it from httpContextAccessor