### PR TITLE
RemoveDefaultLogging to prevent full  URL in Log-Scope

### DIFF
--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>1.0.3-alpha.2</Version>
+		<Version>1.0.4</Version>
 		<authors>Folkehelseinstituttet (FHI)</authors>
 		<Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -25,6 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Refit" Version="7.0.0" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.24" />

--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>1.0.4</Version>
+		<Version>1.1</Version>
 		<authors>Folkehelseinstituttet (FHI)</authors>
 		<Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Fhi.ClientCredentials.Refit/FhiHeaderDelegationHandler.cs
+++ b/Fhi.ClientCredentials.Refit/FhiHeaderDelegationHandler.cs
@@ -4,6 +4,8 @@ namespace Fhi.ClientCredentials.Refit;
 
 public class FhiHeaderDelegationHandler : DelegatingHandler
 {
+    private const string FhiHeaderPrefix = "fhi-";
+
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var headers = request
@@ -12,7 +14,7 @@ public class FhiHeaderDelegationHandler : DelegatingHandler
 
         foreach (var header in headers)
         {
-            if (header.Key.StartsWith("fhi-"))
+            if (header.Key.StartsWith(FhiHeaderPrefix))
             {
                 request.Headers.Remove(header.Key);
                 request.Headers.Add(header.Key, HttpUtility.HtmlEncode(header.Value));

--- a/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
+++ b/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
@@ -5,53 +5,53 @@ namespace Fhi.ClientCredentials.Refit;
 
 public class LoggingDelegationHandler : DelegatingHandler
 {
-	private const string LogMessage = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with response {StatusCode} {Reason} with CorrelationId {CorrelationId}";
-	private const string LogMessageError = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with exception {Exception} with CorrelationId {CorrelationId}";
+    private const string LogMessage = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with response {StatusCode} {Reason} with CorrelationId {CorrelationId}";
+    private const string LogMessageError = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with exception {Exception} with CorrelationId {CorrelationId}";
 
-	private readonly ILogger<LoggingDelegationHandler> logger;
+    private readonly ILogger<LoggingDelegationHandler> logger;
 
-	public LoggingDelegationHandler(ILogger<LoggingDelegationHandler> logger)
-	{
-		this.logger = logger;
-	}
+    public LoggingDelegationHandler(ILogger<LoggingDelegationHandler> logger)
+    {
+        this.logger = logger;
+    }
 
-	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-	{
-		var correalationId = request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHandler.CorrelationIdHeaderName).Value?.FirstOrDefault();
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var correalationId = request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHandler.CorrelationIdHeaderName).Value?.FirstOrDefault();
 
-		var logUrl = AnonymizePersonalIdentifiers(request.RequestUri?.GetLeftPart(UriPartial.Path).ToString());
+        var logUrl = AnonymizePersonalIdentifiers(request.RequestUri?.GetLeftPart(UriPartial.Path).ToString());
 
-		var start = DateTime.Now;
-		try
-		{
-			var response = await base.SendAsync(request, cancellationToken);
-			var time = (int)(DateTime.Now - start).TotalMilliseconds;
+        var start = DateTime.Now;
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            var time = (int)(DateTime.Now - start).TotalMilliseconds;
 
-			if (response.IsSuccessStatusCode)
-			{
-				logger.LogInformation(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
-			}
-			else
-			{
-				logger.LogWarning(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
-			}
+            if (response.IsSuccessStatusCode)
+            {
+                logger.LogInformation(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
+            }
+            else
+            {
+                logger.LogWarning(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
+            }
 
-			return response;
-		}
-		catch (Exception ex)
-		{
-			var time = (int)(DateTime.Now - start).TotalMilliseconds;
-			logger.LogError(ex, LogMessageError, request.Method, logUrl, time, ex.Message, correalationId);
-			throw;
-		}
-	}
+            return response;
+        }
+        catch (Exception ex)
+        {
+            var time = (int)(DateTime.Now - start).TotalMilliseconds;
+            logger.LogError(ex, LogMessageError, request.Method, logUrl, time, ex.Message, correalationId);
+            throw;
+        }
+    }
 
-	public static string? AnonymizePersonalIdentifiers(string? sourceToAnonymize)
-	{
-		if (string.IsNullOrWhiteSpace(sourceToAnonymize))
-			return sourceToAnonymize;
+    public static string? AnonymizePersonalIdentifiers(string? sourceToAnonymize)
+    {
+        if (string.IsNullOrWhiteSpace(sourceToAnonymize))
+            return sourceToAnonymize;
 
-		return Regex.Replace(sourceToAnonymize, "\\d{6,11}", "***********");
-	}
+        return Regex.Replace(sourceToAnonymize, "\\d{6,11}", "***********");
+    }
 }
 

--- a/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
+++ b/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
@@ -7,51 +7,51 @@ public class LoggingDelegationHandler : DelegatingHandler
 {
 	private const string LogMessage = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with response {StatusCode} {Reason} with CorrelationId {CorrelationId}";
 	private const string LogMessageError = "Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with exception {Exception} with CorrelationId {CorrelationId}";
-	
-    private readonly ILogger<LoggingDelegationHandler> logger;
 
-    public LoggingDelegationHandler(ILogger<LoggingDelegationHandler> logger)
-    {
-        this.logger = logger;
-    }
+	private readonly ILogger<LoggingDelegationHandler> logger;
 
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	public LoggingDelegationHandler(ILogger<LoggingDelegationHandler> logger)
+	{
+		this.logger = logger;
+	}
+
+	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 	{
 		var correalationId = request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHandler.CorrelationIdHeaderName).Value?.FirstOrDefault();
 
-        var logUrl = AnonymizePersonalIdentifiers(request.RequestUri?.GetLeftPart(UriPartial.Path).ToString());
+		var logUrl = AnonymizePersonalIdentifiers(request.RequestUri?.GetLeftPart(UriPartial.Path).ToString());
 
 		var start = DateTime.Now;
-        try
-        {
-            var response = await base.SendAsync(request, cancellationToken);
-            var time = (int)(DateTime.Now - start).TotalMilliseconds;
+		try
+		{
+			var response = await base.SendAsync(request, cancellationToken);
+			var time = (int)(DateTime.Now - start).TotalMilliseconds;
 
-            if (response.IsSuccessStatusCode)
-            {
-                logger.LogInformation(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
-            }
-            else
-            {
-                logger.LogWarning(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
-            }
+			if (response.IsSuccessStatusCode)
+			{
+				logger.LogInformation(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
+			}
+			else
+			{
+				logger.LogWarning(LogMessage, request.Method, logUrl, time, (int)response.StatusCode, response.ReasonPhrase, correalationId);
+			}
 
-            return response;
-        }
-        catch (Exception ex)
-        {
-            var time = (int)(DateTime.Now - start).TotalMilliseconds;
-            logger.LogError(ex, LogMessageError, request.Method, logUrl, time, ex.Message, correalationId);
-            throw;
-        }
-    }
+			return response;
+		}
+		catch (Exception ex)
+		{
+			var time = (int)(DateTime.Now - start).TotalMilliseconds;
+			logger.LogError(ex, LogMessageError, request.Method, logUrl, time, ex.Message, correalationId);
+			throw;
+		}
+	}
 
-    public static string? AnonymizePersonalIdentifiers(string? sourceToAnonymize)
-    {
-        if (string.IsNullOrWhiteSpace(sourceToAnonymize))
-            return sourceToAnonymize;
+	public static string? AnonymizePersonalIdentifiers(string? sourceToAnonymize)
+	{
+		if (string.IsNullOrWhiteSpace(sourceToAnonymize))
+			return sourceToAnonymize;
 
-        return Regex.Replace(sourceToAnonymize, "\\d{6,11}", "***********");
-    }
+		return Regex.Replace(sourceToAnonymize, "\\d{6,11}", "***********");
+	}
 }
 

--- a/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
+++ b/Fhi.ClientCredentials.Refit/LoggingDelegationHandler.cs
@@ -46,12 +46,19 @@ public class LoggingDelegationHandler : DelegatingHandler
         }
     }
 
-    public static string? AnonymizePersonalIdentifiers(string? sourceToAnonymize)
+    /// <summary>
+    /// Function to anonymize a string, replacing all Norwegian National Identification Numbers (11 digits) with starts.
+    /// </summary>
+    /// <param name="sourceToAnonymize">A string that might contain a NIN.</param>
+    /// <returns>The string, with NINs replaced with "***********"</returns>
+    public static string AnonymizePersonalIdentifiers(string? sourceToAnonymize)
     {
         if (string.IsNullOrWhiteSpace(sourceToAnonymize))
-            return sourceToAnonymize;
+        {
+            return sourceToAnonymize ?? "";
+        }
 
-        return Regex.Replace(sourceToAnonymize, "\\d{6,11}", "***********");
+        return Regex.Replace(sourceToAnonymize, "\\d{11}", "***********");
     }
 }
 

--- a/Fhi.ClientCredentials.Refit/README.md
+++ b/Fhi.ClientCredentials.Refit/README.md
@@ -2,24 +2,20 @@
 
 This package contains code to simplify working with Refit and HelseId. 
 
-This default setup will add a token handler to your Refit Interface in addition to letting you add multiple delegates if needed (f.ex. logging).
-
 ## Usage
 
-Include thhis code in your WebApi startup builder:
+Include this code in your WebApi startup builder. 
+Don't forget to call UseCorrelationId() after building your application if you are using Corellation Id:
 
 ```
 builder.AddClientCredentialsRefitBuilder()
     .AddRefitClient<IMyRefitClient>();
+
+...
+
+app.UseCorrelationId();
 ```
 
-If you want to add additional loggers add them before "AddRefitClient": 
-
-```
-builder.AddClientCredentialsRefitBuilder()
-    .AddHandler<MyLoggingDelegationHandler>()
-    .AddRefitClient<IMyRefitClient>();
-```
 The code loads your configuration from IConfiguration using the section "ClientCredentialsConfiguration".
 If you want to override which section to use you can pass the correct section to AddClientCredentialsKeypairs:
 
@@ -36,9 +32,33 @@ builder.AddClientCredentialsRefitBuilder(new RefitSettings())
     .AddRefitClient<IMyRefitClient>();
 ```
 
-## Adding Correlation Id to all requests
+## Options
 
-Use "AddCorrelationId()" to add header propagation of the default FHI correlation id header. 
+This default setup will add a token handler, logging handler, correlationId handler and an header-encoding handler
+to your Refit Interface. In addition you can add multiple custom delegates if needed.
+
+To add custom delegates use the AddHandler() function:
+
+```
+builder.AddClientCredentialsRefitBuilder()
+    .AddHandler<MyOwnLoggingDelegationHandler>();
+```
+
+You can also choose which handlers to use if you prefer not to use all the default handlers:
+```
+builder.AddClientCredentialsRefitBuilder(builderOptions: new RefitClientCredentialsBuilderOptions()
+    {
+        UseAnonymizationLogger = true,
+        HtmlEncodeFhiHeaders = true,
+        UseCorrelationId = true,
+        UseDefaultTokenHandler = true,
+    })
+    .AddRefitClient<IMyRefitClient>();
+```
+
+## Correlation Id
+
+The Correlation Id Handler adds header propagation of the default FHI correlation id header. 
 
 ```
 builder.AddClientCredentialsRefitBuilder()
@@ -55,12 +75,8 @@ app.UseCorrelationId();
 
 ## Logging
 
-Add the handler "LoggingDelegationHandler" to automatically log all Refit requets. The logger has to be availible trough dependency injection using Microsoft.Extensions.Logging (ILogger).
-
-```
-builder.AddClientCredentialsRefitBuilder()
-    .AddHandler<LoggingDelegationHandler>();
-```
+The handler "LoggingDelegationHandler" log all Refit requets with anonymized URLs. 
+The logger requires dependency injection of a Microsoft.Extensions.Logging.ILogger.
 
 The LoggingDelegationHandler will log the following messages. Uri will have all Nowrwegian National identity numbers replaced with start '***********), and the query parameters removed:
 
@@ -69,22 +85,36 @@ The LoggingDelegationHandler will log the following messages. Uri will have all 
     Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with exception {Exception} with CorrelationId {CorrelationId}
 ```
 
-Adding the LoggingDelegationHandler will automatically remove the default HttpClientFactory logger!
+## WebApi Default Logger issues
+
 The default implementation of HttpClientFactry sets the complete URI in the logging Scope, 
 which might contain sensitive information that we are not able to remove.
 
-If you wish to preserve the standard logger you can configure it:
+F.ex. will your log include this if you are using structured logging (json etc):
+
+    Scope: [{ "HTTP GET http://api/person/12345678901/?evenDangerousQueryParams=true"}]
+
+We therefore remove all default loggers created by the WebApi-framework.
+
+If you wish to preserve the default loggers use
 
 ```
-builder.AddClientCredentialsRefitBuilder()
-    .ConfigureDefaultLogging(preserveDefaultLogger: true)
-    .AddHandler<LoggingDelegationHandler>();
+builder.AddClientCredentialsRefitBuilder(builderOptions: new RefitClientCredentialsBuilderOptions()
+    {
+        PreserveDefaultLogger = true,
+    })
+    .AddRefitClient<IMyRefitClient>();
 ```
 
-or if you want to remove the default logger when using your own logger:
+## Header encoding
 
-```
-builder.AddClientCredentialsRefitBuilder()
-    .ConfigureDefaultLogging(preserveDefaultLogger: false)
-    .AddHandler<MyOwnLoggingDelegationHandler>();
-```
+If HtmlEncodeFhiHeaders is enabled all headers starting with the prefix "fhi-" will be automatically Html-encoded.
+This is usefull when using headers like "fhi-organization-name", which might contain illegal HTTP header characters.
+
+The HTML encoding should only encode characters that normally are illegal in as header values, so the alternative is requests
+failing because of illegal headers.
+
+Note that headers are not automatically decoded on the receiving server! You will still have to do your own
+decoding (using HttpUtility.HtmlDecode or similar), as there are no standard header-encoding rules.
+
+Html-encoding is used over Url-encoding, since more "normal" characters, like spaces, are preserved.

--- a/Fhi.ClientCredentials.Refit/README.md
+++ b/Fhi.ClientCredentials.Refit/README.md
@@ -53,11 +53,38 @@ Remember to add usage of header propagation to your app startup code. It should 
 app.UseCorrelationId();
 ```
 
-## More!
+## Logging
 
 Add the handler "LoggingDelegationHandler" to automatically log all Refit requets. The logger has to be availible trough dependency injection using Microsoft.Extensions.Logging (ILogger).
 
 ```
 builder.AddClientCredentialsRefitBuilder()
     .AddHandler<LoggingDelegationHandler>();
+```
+
+The LoggingDelegationHandler will log the following messages. Uri will have all Nowrwegian National identity numbers replaced with start '***********), and the query parameters removed:
+
+```
+    Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with response {StatusCode} {Reason} with CorrelationId {CorrelationId}
+    Requested HTTP {RequestMethod} {Uri} in {Elapsed}ms with exception {Exception} with CorrelationId {CorrelationId}
+```
+
+Adding the LoggingDelegationHandler will automatically remove the default HttpClientFactory logger!
+The default implementation of HttpClientFactry sets the complete URI in the logging Scope, 
+which might contain sensitive information that we are not able to remove.
+
+If you wish to preserve the standard logger you can configure it:
+
+```
+builder.AddClientCredentialsRefitBuilder()
+    .ConfigureDefaultLogging(preserveDefaultLogger: true)
+    .AddHandler<LoggingDelegationHandler>();
+```
+
+or if you want to remove the default logger when using your own logger:
+
+```
+builder.AddClientCredentialsRefitBuilder()
+    .ConfigureDefaultLogging(preserveDefaultLogger: false)
+    .AddHandler<MyOwnLoggingDelegationHandler>();
 ```

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -68,7 +68,7 @@ public class RefitClientCredentialsBuilder
 	/// <returns></returns>
 	public RefitClientCredentialsBuilder ConfigureDefaultLogging(bool preserveDefaultLogger)
 	{
-		options.RemoveDefaultLogging = !preserveDefaultLogger;
+		options.PreserveDefaultLogger = preserveDefaultLogger;
 		return this;
 	}
 
@@ -80,8 +80,8 @@ public class RefitClientCredentialsBuilder
                 httpClient.BaseAddress = clientCredentialsConfig.UriToApiByName(nameOfService ?? typeof(T).Name);
 			});
 
-        if (options.RemoveDefaultLogging == true ||
-            (options.RemoveDefaultLogging == null &&
+        if (options.PreserveDefaultLogger == false ||
+            (options.PreserveDefaultLogger == null &&
 			DelegationHandlers.Any(x => x == typeof(LoggingDelegationHandler))))
         {
             clientBuilder.RemoveAllLoggers();

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -8,110 +8,110 @@ namespace Fhi.ClientCredentials.Refit;
 
 public class RefitClientCredentialsBuilder
 {
-	private List<Type> DelegationHandlers = new();
-	private readonly IServiceCollection services;
-	private readonly ClientCredentialsConfiguration clientCredentialsConfig;
-	private readonly RefitClientCredentialsBuilderOptions options = new RefitClientCredentialsBuilderOptions();
+    private List<Type> DelegationHandlers = new();
+    private readonly IServiceCollection services;
+    private readonly ClientCredentialsConfiguration clientCredentialsConfig;
+    private readonly RefitClientCredentialsBuilderOptions options = new RefitClientCredentialsBuilderOptions();
 
-	public RefitSettings RefitSettings { get; set; }
+    public RefitSettings RefitSettings { get; set; }
 
-	public RefitClientCredentialsBuilder(IServiceCollection services, ClientCredentialsConfiguration config, RefitSettings? refitSettings)
-	{
-		RefitSettings = refitSettings ?? CreateRefitSettings();
+    public RefitClientCredentialsBuilder(IServiceCollection services, ClientCredentialsConfiguration config, RefitSettings? refitSettings)
+    {
+        RefitSettings = refitSettings ?? CreateRefitSettings();
 
-		this.services = services;
-		clientCredentialsConfig = config;
+        this.services = services;
+        clientCredentialsConfig = config;
 
-		services.AddTransient<IAuthenticationService>(_ => new AuthenticationService(config));
-		services.AddSingleton<IAuthTokenStore, AuthenticationStore>();
+        services.AddTransient<IAuthenticationService>(_ => new AuthenticationService(config));
+        services.AddSingleton<IAuthTokenStore, AuthenticationStore>();
 
-		services.AddSingleton(options);
+        services.AddSingleton(options);
 
-		AddHandler<HttpAuthHandler>();
-		AddHandler<FhiHeaderDelegationHandler>();
-	}
+        AddHandler<HttpAuthHandler>();
+        AddHandler<FhiHeaderDelegationHandler>();
+    }
 
-	public RefitClientCredentialsBuilder AddHandler<T>() where T : DelegatingHandler
-	{
-		DelegationHandlers.Add(typeof(T));
-		services.AddTransient<T>();
-		return this;
-	}
+    public RefitClientCredentialsBuilder AddHandler<T>() where T : DelegatingHandler
+    {
+        DelegationHandlers.Add(typeof(T));
+        services.AddTransient<T>();
+        return this;
+    }
 
-	public RefitClientCredentialsBuilder ClearHandlers()
-	{
-		DelegationHandlers.Clear();
-		return this;
-	}
+    public RefitClientCredentialsBuilder ClearHandlers()
+    {
+        DelegationHandlers.Clear();
+        return this;
+    }
 
-	/// <summary>
-	/// Adds propagation and handling of correlation ids. You should add this before any logging-delagates. Remember to add "app.UseCorrelationId()" in your startup code
-	/// </summary>
-	/// <returns></returns>
-	public RefitClientCredentialsBuilder AddCorrelationId()
-	{
-		options.UseCorrelationId = true;
+    /// <summary>
+    /// Adds propagation and handling of correlation ids. You should add this before any logging-delagates. Remember to add "app.UseCorrelationId()" in your startup code
+    /// </summary>
+    /// <returns></returns>
+    public RefitClientCredentialsBuilder AddCorrelationId()
+    {
+        options.UseCorrelationId = true;
 
-		AddHandler<CorrelationIdHandler>();
+        AddHandler<CorrelationIdHandler>();
 
-		services.AddHttpContextAccessor();
+        services.AddHttpContextAccessor();
 
-		return this;
-	}
+        return this;
+    }
 
-	/// <summary>
-	/// The default implementation of HttpClientFactry sets the complete URI in the logging Scope,
-	/// which might contain sensitive information that we are not able to remove.
-	/// We therefore wish to remove the default logger. Use this method if you want to preserve it.
-	/// </summary>
-	/// <param name="preserveDefaultLogger"></param>
-	/// <returns></returns>
-	public RefitClientCredentialsBuilder ConfigureDefaultLogging(bool preserveDefaultLogger)
-	{
-		options.PreserveDefaultLogger = preserveDefaultLogger;
-		return this;
-	}
+    /// <summary>
+    /// The default implementation of HttpClientFactry sets the complete URI in the logging Scope,
+    /// which might contain sensitive information that we are not able to remove.
+    /// We therefore wish to remove the default logger. Use this method if you want to preserve it.
+    /// </summary>
+    /// <param name="preserveDefaultLogger"></param>
+    /// <returns></returns>
+    public RefitClientCredentialsBuilder ConfigureDefaultLogging(bool preserveDefaultLogger)
+    {
+        options.PreserveDefaultLogger = preserveDefaultLogger;
+        return this;
+    }
 
-	public RefitClientCredentialsBuilder AddRefitClient<T>(string? nameOfService = null, Func<IHttpClientBuilder, IHttpClientBuilder>? extra = null) where T : class
-	{
-		var clientBuilder = services.AddRefitClient<T>(RefitSettings)
-			.ConfigureHttpClient(httpClient =>
-			{
-				httpClient.BaseAddress = clientCredentialsConfig.UriToApiByName(nameOfService ?? typeof(T).Name);
-			});
+    public RefitClientCredentialsBuilder AddRefitClient<T>(string? nameOfService = null, Func<IHttpClientBuilder, IHttpClientBuilder>? extra = null) where T : class
+    {
+        var clientBuilder = services.AddRefitClient<T>(RefitSettings)
+            .ConfigureHttpClient(httpClient =>
+            {
+                httpClient.BaseAddress = clientCredentialsConfig.UriToApiByName(nameOfService ?? typeof(T).Name);
+            });
 
-		if (options.PreserveDefaultLogger == false ||
-			(options.PreserveDefaultLogger == null &&
-			DelegationHandlers.Any(x => x == typeof(LoggingDelegationHandler))))
-		{
-			clientBuilder.RemoveAllLoggers();
-		}
+        if (options.PreserveDefaultLogger == false ||
+            (options.PreserveDefaultLogger == null &&
+            DelegationHandlers.Any(x => x == typeof(LoggingDelegationHandler))))
+        {
+            clientBuilder.RemoveAllLoggers();
+        }
 
-		foreach (var type in DelegationHandlers)
-		{
-			clientBuilder.AddHttpMessageHandler((s) => (DelegatingHandler)s.GetRequiredService(type));
-		}
+        foreach (var type in DelegationHandlers)
+        {
+            clientBuilder.AddHttpMessageHandler((s) => (DelegatingHandler)s.GetRequiredService(type));
+        }
 
-		extra?.Invoke(clientBuilder);
+        extra?.Invoke(clientBuilder);
 
-		return this;
-	}
+        return this;
+    }
 
-	private static RefitSettings CreateRefitSettings()
-	{
-		var jsonOptions = new JsonSerializerOptions()
-		{
-			PropertyNameCaseInsensitive = true,
-			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-		};
+    private static RefitSettings CreateRefitSettings()
+    {
+        var jsonOptions = new JsonSerializerOptions()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
 
-		jsonOptions.Converters.Add(new JsonStringEnumConverter());
+        jsonOptions.Converters.Add(new JsonStringEnumConverter());
 
-		var refitSettings = new RefitSettings()
-		{
-			ContentSerializer = new SystemTextJsonContentSerializer(jsonOptions),
-		};
+        var refitSettings = new RefitSettings()
+        {
+            ContentSerializer = new SystemTextJsonContentSerializer(jsonOptions),
+        };
 
-		return refitSettings;
-	}
+        return refitSettings;
+    }
 }

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
@@ -2,7 +2,7 @@
 
 public class RefitClientCredentialsBuilderOptions
 {
-	public bool UseCorrelationId { get; set; }
+    public bool UseCorrelationId { get; set; }
 
-	public bool? PreserveDefaultLogger { get; set; }
+    public bool? PreserveDefaultLogger { get; set; }
 }

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
@@ -4,5 +4,5 @@ public class RefitClientCredentialsBuilderOptions
 {
     public bool UseCorrelationId { get; set; }
 
-    public bool? RemoveDefaultLogging { get; set; }
+    public bool? PreserveDefaultLogger { get; set; }
 }

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
@@ -2,7 +2,7 @@
 
 public class RefitClientCredentialsBuilderOptions
 {
-    public bool UseCorrelationId { get; set; }
+	public bool UseCorrelationId { get; set; }
 
-    public bool? PreserveDefaultLogger { get; set; }
+	public bool? PreserveDefaultLogger { get; set; }
 }

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
@@ -3,4 +3,6 @@
 public class RefitClientCredentialsBuilderOptions
 {
     public bool UseCorrelationId { get; set; }
+
+    public bool? RemoveDefaultLogging { get; set; }
 }

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilderOptions.cs
@@ -1,8 +1,39 @@
 ﻿namespace Fhi.ClientCredentials.Refit;
 
+/// <summary>
+/// Options for customizing the default options used when creating Refit clients
+/// </summary>
 public class RefitClientCredentialsBuilderOptions
 {
-    public bool UseCorrelationId { get; set; }
+    /// <summary>
+    /// Adds the default token handler from Fhi.ClientCredentials, HttpAuthHandler.
+    /// Set to false if you wish to use a custom token handler.
+    /// </summary>
+    public bool UseDefaultTokenHandler { get; set; } = true;
 
-    public bool? PreserveDefaultLogger { get; set; }
+    /// <summary>
+    /// Adds propagation and handling of correlation ids to all Refit-Requests. 
+    /// Remember to add "app.UseCorrelationId()" in your startup code.
+    /// </summary>
+    public bool UseCorrelationId { get; set; } = true;
+
+    /// <summary>
+    /// Html-encodes all headers starting with the prefix "fhi-".
+    /// This is usefull when using headers like "fhi-organization-name", which might contain
+    /// illegal HTTP header characters.
+    /// </summary>
+    public bool HtmlEncodeFhiHeaders { get; set; } = true;
+
+    /// <summary>
+    /// Adds logging to all requests using LoggingDelegationHandler.
+    /// The handler anonymizes all NIN-like requets paths and removes query strings from the log URL.
+    /// </summary>
+    public bool UseAnonymizationLogger { get; set; } = true;
+
+    /// <summary>
+    /// The default implementation of HttpClientFactry sets the complete URI in the logging Scope,
+    /// which might contain sensitive information that we are not able to remove.
+    /// We therefore remove the default logger. Set to true if you want to preserve the default logger.
+    /// </summary>
+    public bool PreserveDefaultLogger { get; set; } = false;
 }

--- a/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
+++ b/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
@@ -6,46 +6,46 @@ using Fhi.ClientCredentialsKeypairs;
 
 namespace Fhi.ClientCredentials.Refit
 {
-	public static class WebApplicationBuilderExtensions
-	{
-		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitSettings? refitSettings = null)
-		{
-			return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, refitSettings);
-		}
+    public static class WebApplicationBuilderExtensions
+    {
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitSettings? refitSettings = null)
+        {
+            return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, refitSettings);
+        }
 
-		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitSettings? refitSettings = null)
-		{
-			var config = configuration
-				.GetSection(configSection ?? nameof(ClientCredentialsConfiguration))
-				.Get<ClientCredentialsConfiguration>();
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitSettings? refitSettings = null)
+        {
+            var config = configuration
+                .GetSection(configSection ?? nameof(ClientCredentialsConfiguration))
+                .Get<ClientCredentialsConfiguration>();
 
-			return AddClientCredentialsRefitBuilder(services, config, refitSettings);
-		}
+            return AddClientCredentialsRefitBuilder(services, config, refitSettings);
+        }
 
-		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitSettings? refitSettings = null)
-		{
-			return new RefitClientCredentialsBuilder(services, configuration, refitSettings);
-		}
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitSettings? refitSettings = null)
+        {
+            return new RefitClientCredentialsBuilder(services, configuration, refitSettings);
+        }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="app"></param>
-		/// <returns></returns>
-		public static T UseCorrelationId<T>(this T app) where T : IApplicationBuilder
-		{
-			var options = app.ApplicationServices.GetService<RefitClientCredentialsBuilderOptions>();
-			if (options == null)
-			{
-				throw new Exception("You need to call builder.AddHelseIdForBlazor() before using app.UseHelseIdForBlazor()");
-			}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="app"></param>
+        /// <returns></returns>
+        public static T UseCorrelationId<T>(this T app) where T : IApplicationBuilder
+        {
+            var options = app.ApplicationServices.GetService<RefitClientCredentialsBuilderOptions>();
+            if (options == null)
+            {
+                throw new Exception("You need to call builder.AddHelseIdForBlazor() before using app.UseHelseIdForBlazor()");
+            }
 
-			if (options.UseCorrelationId)
-			{
-				app.UseMiddleware<CorrelationIdMiddleware>();
-			}
+            if (options.UseCorrelationId)
+            {
+                app.UseMiddleware<CorrelationIdMiddleware>();
+            }
 
-			return app;
-		}
-	}
+            return app;
+        }
+    }
 }

--- a/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
+++ b/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
@@ -8,23 +8,23 @@ namespace Fhi.ClientCredentials.Refit
 {
     public static class WebApplicationBuilderExtensions
     {
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitSettings? refitSettings = null)
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitClientCredentialsBuilderOptions? builderOptions = null, RefitSettings? refitSettings = null)
         {
-            return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, refitSettings);
+            return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, builderOptions, refitSettings);
         }
 
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitSettings? refitSettings = null)
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitClientCredentialsBuilderOptions? builderOptions = null, RefitSettings? refitSettings = null)
         {
             var config = configuration
                 .GetSection(configSection ?? nameof(ClientCredentialsConfiguration))
                 .Get<ClientCredentialsConfiguration>();
 
-            return AddClientCredentialsRefitBuilder(services, config, refitSettings);
+            return AddClientCredentialsRefitBuilder(services, config, builderOptions, refitSettings);
         }
 
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitSettings? refitSettings = null)
+        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitClientCredentialsBuilderOptions? builderOptions = null, RefitSettings? refitSettings = null)
         {
-            return new RefitClientCredentialsBuilder(services, configuration, refitSettings);
+            return new RefitClientCredentialsBuilder(services, configuration, refitSettings, builderOptions);
         }
 
         /// <summary>
@@ -37,12 +37,13 @@ namespace Fhi.ClientCredentials.Refit
             var options = app.ApplicationServices.GetService<RefitClientCredentialsBuilderOptions>();
             if (options == null)
             {
-                throw new Exception("You need to call builder.AddHelseIdForBlazor() before using app.UseHelseIdForBlazor()");
+                throw new Exception("You need to call builder.AddClientCredentialsRefitBuilder() before using app.UseCorrelationId()");
             }
 
             if (options.UseCorrelationId)
             {
                 app.UseMiddleware<CorrelationIdMiddleware>();
+                app.UseHeaderPropagation();
             }
 
             return app;

--- a/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
+++ b/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
@@ -6,46 +6,46 @@ using Fhi.ClientCredentialsKeypairs;
 
 namespace Fhi.ClientCredentials.Refit
 {
-    public static class WebApplicationBuilderExtensions
-    {
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitSettings? refitSettings = null)
-        {
-            return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, refitSettings);
-        }
+	public static class WebApplicationBuilderExtensions
+	{
+		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this WebApplicationBuilder builder, string? configSection = null, RefitSettings? refitSettings = null)
+		{
+			return AddClientCredentialsRefitBuilder(builder.Services, builder.Configuration, configSection, refitSettings);
+		}
 
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitSettings? refitSettings = null)
-        {
-            var config = configuration
-                .GetSection(configSection ?? nameof(ClientCredentialsConfiguration))
-                .Get<ClientCredentialsConfiguration>();
+		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, IConfiguration configuration, string? configSection = null, RefitSettings? refitSettings = null)
+		{
+			var config = configuration
+				.GetSection(configSection ?? nameof(ClientCredentialsConfiguration))
+				.Get<ClientCredentialsConfiguration>();
 
-            return AddClientCredentialsRefitBuilder(services, config, refitSettings);
-        }
+			return AddClientCredentialsRefitBuilder(services, config, refitSettings);
+		}
 
-        public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitSettings? refitSettings = null)
-        {
-            return new RefitClientCredentialsBuilder(services, configuration, refitSettings);
-        }
+		public static RefitClientCredentialsBuilder AddClientCredentialsRefitBuilder(this IServiceCollection services, ClientCredentialsConfiguration configuration, RefitSettings? refitSettings = null)
+		{
+			return new RefitClientCredentialsBuilder(services, configuration, refitSettings);
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="app"></param>
-        /// <returns></returns>
-        public static T UseCorrelationId<T>(this T app) where T : IApplicationBuilder
-        {
-            var options = app.ApplicationServices.GetService<RefitClientCredentialsBuilderOptions>();
-            if (options == null)
-            {
-                throw new Exception("You need to call builder.AddHelseIdForBlazor() before using app.UseHelseIdForBlazor()");
-            }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="app"></param>
+		/// <returns></returns>
+		public static T UseCorrelationId<T>(this T app) where T : IApplicationBuilder
+		{
+			var options = app.ApplicationServices.GetService<RefitClientCredentialsBuilderOptions>();
+			if (options == null)
+			{
+				throw new Exception("You need to call builder.AddHelseIdForBlazor() before using app.UseHelseIdForBlazor()");
+			}
 
-            if (options.UseCorrelationId)
-            {
-                app.UseMiddleware<CorrelationIdMiddleware>();
-            }
+			if (options.UseCorrelationId)
+			{
+				app.UseMiddleware<CorrelationIdMiddleware>();
+			}
 
-            return app;
-        }
-    }
+			return app;
+		}
+	}
 }


### PR DESCRIPTION
vi har gått over til strukturert logging, og da ser vi at HttpClientFactory som WebApi bruker setter Scope på loggeren som inneholder hele url'en man requester
så i json-loggen kommer det med
Scope: [{ "HTTP GET http://api/person/12345678901/?tilOgmedFarligQueryParams=true"}]
så tanken er å ikke bruke standard scopes som blir automatisk lagt til, og bruke anonymiserende loggeren i stede