### PR TITLE
Skip Auth header if Anonymous-Property is given to request message

### DIFF
--- a/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
+++ b/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.2.1</Version>
+    <Version>1.3.0</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>(c) 2022-2023 Folkehelseinstituttet (FHI)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
+++ b/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>(c) 2022-2023 Folkehelseinstituttet (FHI)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ClientCredentialsKeypairs/HttpAuthHandler.cs
+++ b/ClientCredentialsKeypairs/HttpAuthHandler.cs
@@ -4,6 +4,8 @@ namespace Fhi.ClientCredentialsKeypairs
 {
     public class HttpAuthHandler : DelegatingHandler
     {
+        public const string AnonymousOptionKey = "Anonymous";
+
         private readonly IAuthTokenStore _authTokenStore;
 
         public HttpAuthHandler(IAuthTokenStore authTokenStore)
@@ -14,8 +16,12 @@ namespace Fhi.ClientCredentialsKeypairs
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var token = await _authTokenStore.GetToken();
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            if (!request.Options.Any(x => x.Key == AnonymousOptionKey))
+            {
+                var token = await _authTokenStore.GetToken();
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+
             var response = await base.SendAsync(request, cancellationToken);
             return response;
         }

--- a/ClientCredentialsKeypairs/HttpAuthHandler.cs
+++ b/ClientCredentialsKeypairs/HttpAuthHandler.cs
@@ -16,7 +16,7 @@ namespace Fhi.ClientCredentialsKeypairs
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (!request.Options.Any(x => x.Key == AnonymousOptionKey))
+            if (request.Options.All(x => x.Key != AnonymousOptionKey))
             {
                 var token = await _authTokenStore.GetToken();
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);

--- a/Readme.md
+++ b/Readme.md
@@ -77,3 +77,21 @@ If you want to disable the authorization for some reason, you can add another pr
 3. In your `Program.cs` file, create an instance of the `ClientCredentialsSetup` class using an `IConfiguration` parameter.
 4. Using the created instance call the method `ConfigureServices`.
 
+## Calling endpoints that does not required authentication
+
+In some cases we might wish to call an API before we are authenticated (health endpoints, kodeverk, etc..).
+
+To make the HttpAuthHandler not add authentication headers to a single request you can add an Option
+to the request with the key name "Anonymous":
+
+```
+var request = new HttpRequestMessage();
+request.Options.TryAdd("Anonymous", "");
+```
+
+or in Refit:
+
+```
+[Get("/info")]
+Task<string> GetInfo([Property("Anonymous")] string anonymous = "");
+```


### PR DESCRIPTION
In some cases we might wish to call an API before we are authenticated (health endpoints, kodeverk, etc..).

By adding a property that can force the auth handler to skip adding the token we don't need to needlessly try to retrieve the token on those calls.