### PR TITLE
Fix for wrong order of adding the logging delegation handler

### DIFF
--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>1.1.1</Version>
+        <Version>1.1.2</Version>
         <id>Fhi.ClientCredentials.Refit</id>
         <authors>Folkehelseinstituttet (FHI)</authors>
         <Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -38,10 +38,6 @@ public class RefitClientCredentialsBuilder
         {
             AddHandler<FhiHeaderDelegationHandler>();
         }
-        if (builderOptions.UseAnonymizationLogger)
-        {
-            AddHandler<LoggingDelegationHandler>();
-        }
         if (builderOptions.UseCorrelationId)
         {
             AddHandler<CorrelationIdHandler>();
@@ -51,6 +47,10 @@ public class RefitClientCredentialsBuilder
             {
                 o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
             });
+        }
+        if (builderOptions.UseAnonymizationLogger)
+        {
+            AddHandler<LoggingDelegationHandler>();
         }
     }
 


### PR DESCRIPTION
Logging handler was added before correlation handler, so logs always outputs null correlation id
