### PR TITLE
Refit: Remove unneeded HeaderPropagation

### DIFF
--- a/Fhi.CLientCredentials.sln
+++ b/Fhi.CLientCredentials.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fhi.ClientCredentials.Tools.GetAccessToken", "Fhi.ClientCredentials.Tools.GetAccessToken\Fhi.ClientCredentials.Tools.GetAccessToken.csproj", "{B5ECA6A3-EAE7-4DD3-A226-EDDC4E670A37}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fhi.ClientCredentials.Refit.Tests", "Fhi.ClientCredentials.Refit.Tests\Fhi.ClientCredentials.Refit.Tests.csproj", "{12203F28-AF24-4909-9959-CB61BA24D9CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{B5ECA6A3-EAE7-4DD3-A226-EDDC4E670A37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B5ECA6A3-EAE7-4DD3-A226-EDDC4E670A37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5ECA6A3-EAE7-4DD3-A226-EDDC4E670A37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12203F28-AF24-4909-9959-CB61BA24D9CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12203F28-AF24-4909-9959-CB61BA24D9CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12203F28-AF24-4909-9959-CB61BA24D9CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12203F28-AF24-4909-9959-CB61BA24D9CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Fhi.ClientCredentials.Refit.Tests;
+
+public class CorrelationIdHandlerTests
+{
+    [Test]
+    public async Task HandlerAddsCorrelationHeader()
+    {
+        var correlationId = Guid.NewGuid().ToString();
+
+        var services = new ServiceCollection();
+
+        var provider = services.BuildServiceProvider();
+
+        var handler = new CorrelationIdHandler(CreateContext(correlationId));
+        handler.InnerHandler = new DummyInnerHandler();
+
+        var client = new HttpClient(handler);
+        var response = await client.GetAsync("http://localhost/");
+
+        var token = await response.Content.ReadAsStringAsync();
+
+        // check that we get the correlation id from HelseIdState
+        Assert.That(response.Headers.Single(x => x.Key == CorrelationIdHandler.CorrelationIdHeaderName).Value.Single(),
+            Is.EqualTo(correlationId));
+    }
+
+    private IHttpContextAccessor CreateContext(string? correlationId)
+    {
+        var headers = new HeaderDictionary();
+        if (correlationId != null)
+        {
+            headers.TryAdd(CorrelationIdHandler.CorrelationIdHeaderName, correlationId);
+        }
+
+        var context = Substitute.For<HttpContext>();
+        context.Request.Headers.Returns(headers);
+
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        return accessor;
+    }
+}

--- a/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -16,7 +18,7 @@ public class CorrelationIdHandlerTests
 
         var provider = services.BuildServiceProvider();
 
-        var handler = new CorrelationIdHandler(CreateContext(correlationId));
+        var handler = new CorrelationIdHandler(CreateContext(correlationId), new HeaderPropagationValues(), Options.Create(new HeaderPropagationOptions()));
         handler.InnerHandler = new DummyInnerHandler();
 
         var client = new HttpClient(handler);

--- a/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/CorrelationIdHandlerTests.cs
@@ -1,7 +1,5 @@
-using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -18,7 +16,7 @@ public class CorrelationIdHandlerTests
 
         var provider = services.BuildServiceProvider();
 
-        var handler = new CorrelationIdHandler(CreateContext(correlationId), new HeaderPropagationValues(), Options.Create(new HeaderPropagationOptions()));
+        var handler = new CorrelationIdHandler(CreateContext(correlationId));
         handler.InnerHandler = new DummyInnerHandler();
 
         var client = new HttpClient(handler);

--- a/Fhi.ClientCredentials.Refit.Tests/DummyInnerHandler.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/DummyInnerHandler.cs
@@ -1,0 +1,20 @@
+﻿namespace Fhi.ClientCredentials.Refit.Tests;
+
+public class DummyInnerHandler : HttpClientHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Get any auth header, and use its value as the content of the request
+        var auth = request.Headers.FirstOrDefault(x => x.Key == "Authorization").Value?.FirstOrDefault() ?? "";
+
+        var response = new HttpResponseMessage() { Content = new StringContent(auth) };
+
+        // add all fhi headers in the request to the respons so we can see if they have been modified
+        foreach (var h in request.Headers.Where(x => x.Key.StartsWith("fhi-")))
+        {
+            response.Headers.Add(h.Key, h.Value);
+        }
+
+        return Task.FromResult(response);
+    }
+}

--- a/Fhi.ClientCredentials.Refit.Tests/Fhi.ClientCredentials.Refit.Tests.csproj
+++ b/Fhi.ClientCredentials.Refit.Tests/Fhi.ClientCredentials.Refit.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" version="4.5.0" />
+        <PackageReference Include="NUnit.Analyzers" version="3.10.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Fhi.ClientCredentials.Refit\Fhi.ClientCredentials.Refit.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Fhi.ClientCredentials.Refit.Tests/FhiHeaderDelegationHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/FhiHeaderDelegationHandlerTests.cs
@@ -13,7 +13,7 @@ public class FhiHeaderDelegationHandlerTests
         handler.InnerHandler = new DummyInnerHandler();
 
         var client = new HttpClient(handler);
-        client.DefaultRequestHeaders.TryAddWithoutValidation(headerName, "'Fornavn' Ætternavn");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(headerName, "'Fornavn' Ã†tternavn");
 
         var response = await client.GetAsync("http://localhost/");
 

--- a/Fhi.ClientCredentials.Refit.Tests/FhiHeaderDelegationHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/FhiHeaderDelegationHandlerTests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Fhi.ClientCredentials.Refit.Tests;
+
+public class FhiHeaderDelegationHandlerTests
+{
+    [Test]
+    public async Task HandlerEncodesValues()
+    {
+        var headerName = "fhi-test";
+
+        var handler = new FhiHeaderDelegationHandler();
+        handler.InnerHandler = new DummyInnerHandler();
+
+        var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.TryAddWithoutValidation(headerName, "'Fornavn' Ætternavn");
+
+        var response = await client.GetAsync("http://localhost/");
+
+        var token = await response.Content.ReadAsStringAsync();
+
+        // check that we get the correlation id from HelseIdState
+        Assert.That(response.Headers.Single(x => x.Key == headerName).Value.Single(),
+            Is.EqualTo("&#39;Fornavn&#39; &#198;tternavn"));
+    }
+}

--- a/Fhi.ClientCredentials.Refit.Tests/LoggingDelegationHandlerTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/LoggingDelegationHandlerTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace Fhi.ClientCredentials.Refit.Tests;
+
+public class LoggingDelegationHandlerTests
+{
+    [Test]
+    public async Task HandlerAnonymizesUris()
+    {
+        var logger = new TestLogger<LoggingDelegationHandler>();
+        var handler = new LoggingDelegationHandler(logger);
+        handler.InnerHandler = new DummyInnerHandler();
+
+        var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.TryAddWithoutValidation(CorrelationIdHandler.CorrelationIdHeaderName, "TESTCORR");
+        await client.GetAsync("http://localhost/get/12345678901/?secret=value");
+
+        Assert.That(logger.Entries.Single(),
+            Contains.Substring("Information Requested HTTP GET http://localhost/get/***********/ in"));
+
+        Assert.That(logger.Entries.Single(),
+            Contains.Substring("with response 200 OK with CorrelationId TESTCORR"));
+    }
+}

--- a/Fhi.ClientCredentials.Refit.Tests/RefitClientCredentialsBuilderTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/RefitClientCredentialsBuilderTests.cs
@@ -2,7 +2,6 @@ using Fhi.ClientCredentialsKeypairs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.JSInterop;
 using NSubstitute;
 using NUnit.Framework;
 using Refit;
@@ -96,7 +95,7 @@ public partial class RefitClientCredentialsBuilderTests
         public const string TestHeaderName = "fhi-encoded";
 
         [Get("/info")]
-        [Headers($"{TestHeaderName}: test æ")]
+        [Headers($"{TestHeaderName}: test Ã¦")]
         Task<ApiResponse<string>> Info();
     }
 }

--- a/Fhi.ClientCredentials.Refit.Tests/RefitClientCredentialsBuilderTests.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/RefitClientCredentialsBuilderTests.cs
@@ -1,0 +1,102 @@
+using Fhi.ClientCredentialsKeypairs;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using NSubstitute;
+using NUnit.Framework;
+using Refit;
+
+namespace Fhi.ClientCredentials.Refit.Tests;
+
+public partial class RefitClientCredentialsBuilderTests
+{
+    private const string AccessTokenValue = "test-token";
+    private const string ContextCorrelationId = "context-correlation-guid";
+
+    [Test]
+    public async Task CanCreateWorkingClient()
+    {
+        var options = new RefitClientCredentialsBuilderOptions();
+
+        var client = CreateTestClient(options, out var provider);
+
+        var response = await client.Info();
+
+        await response.EnsureSuccessStatusCodeAsync();
+
+        // the dummy client returns the authorization header
+        Assert.That(response.Content, Is.EqualTo("Bearer " + AccessTokenValue));
+
+        // the dummy client mirrors all "fhi-" headers. Let's check that they are encoded correctly
+        Assert.That(response.Headers.Single(x => x.Key == ITestClient.TestHeaderName).Value.Single(),
+            Is.EqualTo("test &#230;"));
+
+        // check that the correlation id is picked up from the state
+        Assert.That(response.Headers.Single(x => x.Key == CorrelationIdHandler.CorrelationIdHeaderName).Value.Single(),
+        Is.EqualTo(ContextCorrelationId));
+
+        var logger = (TestLogger<LoggingDelegationHandler>)provider.GetRequiredService<ILogger<LoggingDelegationHandler>>();
+        Assert.That(logger.Entries.Any(x => x.Contains(ContextCorrelationId)), Is.True, "Correlation id not found: " + logger.Entries.First());
+    }
+
+    public ITestClient CreateTestClient(RefitClientCredentialsBuilderOptions options, out ServiceProvider provider)
+    {
+        var services = CreateDefaultServiceCollection();
+
+        var config = new ClientCredentialsConfiguration()
+        {
+            Apis = new List<Api>() { new() { Url = "http://localhost", Name = "ITestClient" } }
+        };
+
+        services.AddSingleton(CreateContextAccessor());
+
+        services.AddClientCredentialsRefitBuilder(config, options)
+            .AddRefitClient<ITestClient>(nameof(ITestClient), clientBuilder =>
+            clientBuilder.ConfigurePrimaryHttpMessageHandler(h =>
+            {
+                return new DummyInnerHandler();
+            }));
+
+        // Add authentication parameters for a logged in user
+        var authStore = Substitute.For<IAuthTokenStore>();
+        authStore.GetToken().Returns(Task.FromResult(AccessTokenValue));
+        services.AddSingleton(authStore);
+
+        provider = services.BuildServiceProvider();
+
+        return provider.GetRequiredService<ITestClient>();
+    }
+
+    private ServiceCollection CreateDefaultServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(TestLogger<>));
+        return services;
+    }
+
+    public IHttpContextAccessor CreateContextAccessor()
+    {
+        var context = Substitute.For<HttpContext>();
+        var request = Substitute.For<HttpRequest>();
+        context.Request.Returns(request);
+
+        var headers = new HeaderDictionary();
+        headers.TryAdd(CorrelationIdHandler.CorrelationIdHeaderName, ContextCorrelationId);
+        request.Headers.Returns(headers);
+
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        return accessor;
+    }
+
+    public interface ITestClient
+    {
+        public const string TestHeaderName = "fhi-encoded";
+
+        [Get("/info")]
+        [Headers($"{TestHeaderName}: test æ")]
+        Task<ApiResponse<string>> Info();
+    }
+}

--- a/Fhi.ClientCredentials.Refit.Tests/TestLogger.cs
+++ b/Fhi.ClientCredentials.Refit.Tests/TestLogger.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Fhi.ClientCredentials.Refit.Tests;
+
+public class TestLogger<T> : ILogger<T>
+{
+    public List<string> Entries = new();
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(logLevel.ToString() + " " + formatter(state, exception));
+    }
+}

--- a/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
+++ b/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
@@ -1,22 +1,31 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.HeaderPropagation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Fhi.ClientCredentials.Refit;
 
 public class CorrelationIdHandler : DelegatingHandler
 {
     public const string CorrelationIdHeaderName = "X-Correlation-ID";
-    private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly HeaderPropagationValues _headerValues;
+    private readonly IOptions<HeaderPropagationOptions> _headerPropagationOptions;
 
-    public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor)
+    public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor,
+        HeaderPropagationValues values,
+        IOptions<HeaderPropagationOptions> headerPropagationOptions)
     {
-        this.httpContextAccessor = httpContextAccessor;
+        _httpContextAccessor = httpContextAccessor;
+        _headerValues = values;
+        _headerPropagationOptions = headerPropagationOptions;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var correlationId = Guid.NewGuid().ToString();
 
-        var context = httpContextAccessor.HttpContext;
+        var context = _httpContextAccessor.HttpContext;
         if (context != null)
         {
             var corrFromContext = context.Request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHeaderName).Value.FirstOrDefault();
@@ -35,6 +44,10 @@ public class CorrelationIdHandler : DelegatingHandler
             request.Headers.Add(CorrelationIdHeaderName, correlationId);
         }
 
+        // Populate the default header propagation values with values from headers if they are not previously set.
+        // This is needed to be able to use the Refit-client outside a HttpContext
+        _headerValues.Headers = _headerValues.Headers ?? GetHeadersFromContextAccessor();
+
         var response = await base.SendAsync(request, cancellationToken);
 
         if (!response.Headers.TryGetValues(CorrelationIdHeaderName, out _))
@@ -43,5 +56,27 @@ public class CorrelationIdHandler : DelegatingHandler
         }
 
         return response;
+    }
+
+    private IDictionary<string, StringValues> GetHeadersFromContextAccessor()
+    {
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        if (_httpContextAccessor.HttpContext?.Request?.Headers != null)
+        {
+            foreach (var entry in _headerPropagationOptions.Value.Headers)
+            {
+                if (!headers.ContainsKey(entry.CapturedHeaderName))
+                {
+                    _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(entry.CapturedHeaderName, out var value);
+                    if (!StringValues.IsNullOrEmpty(value))
+                    {
+                        headers.Add(entry.CapturedHeaderName, value);
+                    }
+                }
+            }
+        }
+
+        return headers;
     }
 }

--- a/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
+++ b/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.AspNetCore.HeaderPropagation;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
+﻿using Microsoft.AspNetCore.Http;
 
 namespace Fhi.ClientCredentials.Refit;
 
@@ -9,16 +6,10 @@ public class CorrelationIdHandler : DelegatingHandler
 {
     public const string CorrelationIdHeaderName = "X-Correlation-ID";
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly HeaderPropagationValues _headerValues;
-    private readonly IOptions<HeaderPropagationOptions> _headerPropagationOptions;
 
-    public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor,
-        HeaderPropagationValues values,
-        IOptions<HeaderPropagationOptions> headerPropagationOptions)
+    public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor)
     {
         _httpContextAccessor = httpContextAccessor;
-        _headerValues = values;
-        _headerPropagationOptions = headerPropagationOptions;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -44,10 +35,6 @@ public class CorrelationIdHandler : DelegatingHandler
             request.Headers.Add(CorrelationIdHeaderName, correlationId);
         }
 
-        // Populate the default header propagation values with values from headers if they are not previously set.
-        // This is needed to be able to use the Refit-client outside a HttpContext
-        _headerValues.Headers = _headerValues.Headers ?? GetHeadersFromContextAccessor();
-
         var response = await base.SendAsync(request, cancellationToken);
 
         if (!response.Headers.TryGetValues(CorrelationIdHeaderName, out _))
@@ -56,27 +43,5 @@ public class CorrelationIdHandler : DelegatingHandler
         }
 
         return response;
-    }
-
-    private IDictionary<string, StringValues> GetHeadersFromContextAccessor()
-    {
-        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
-
-        if (_httpContextAccessor.HttpContext?.Request?.Headers != null)
-        {
-            foreach (var entry in _headerPropagationOptions.Value.Headers)
-            {
-                if (!headers.ContainsKey(entry.CapturedHeaderName))
-                {
-                    _httpContextAccessor.HttpContext.Request.Headers.TryGetValue(entry.CapturedHeaderName, out var value);
-                    if (!StringValues.IsNullOrEmpty(value))
-                    {
-                        headers.Add(entry.CapturedHeaderName, value);
-                    }
-                }
-            }
-        }
-
-        return headers;
     }
 }

--- a/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
+++ b/Fhi.ClientCredentials.Refit/CorrelationIdHandler.cs
@@ -5,18 +5,18 @@ namespace Fhi.ClientCredentials.Refit;
 public class CorrelationIdHandler : DelegatingHandler
 {
     public const string CorrelationIdHeaderName = "X-Correlation-ID";
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IHttpContextAccessor httpContextAccessor;
 
     public CorrelationIdHandler(IHttpContextAccessor httpContextAccessor)
     {
-        _httpContextAccessor = httpContextAccessor;
+        this.httpContextAccessor = httpContextAccessor;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var correlationId = Guid.NewGuid().ToString();
 
-        var context = _httpContextAccessor.HttpContext;
+        var context = httpContextAccessor.HttpContext;
         if (context != null)
         {
             var corrFromContext = context.Request.Headers.FirstOrDefault(x => x.Key == CorrelationIdHeaderName).Value.FirstOrDefault();

--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>1.1.1</Version>
+        <Version>1.1.2-alpha.1</Version>
         <id>Fhi.ClientCredentials.Refit</id>
         <authors>Folkehelseinstituttet (FHI)</authors>
         <Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using Fhi.ClientCredentialsKeypairs;
-using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Primitives;
 using Refit;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -43,12 +41,7 @@ public class RefitClientCredentialsBuilder
         if (builderOptions.UseCorrelationId)
         {
             AddHandler<CorrelationIdHandler>();
-
             services.AddHttpContextAccessor();
-            services.AddHeaderPropagation(o =>
-            {
-                o.Headers.Add(CorrelationIdHandler.CorrelationIdHeaderName, context => string.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue);
-            });
         }
         if (builderOptions.UseAnonymizationLogger)
         {
@@ -95,11 +88,6 @@ public class RefitClientCredentialsBuilder
         foreach (var type in DelegationHandlers)
         {
             clientBuilder.AddHttpMessageHandler((s) => (DelegatingHandler)s.GetRequiredService(type));
-        }
-
-        if (builderOptions.UseCorrelationId)
-        {
-            clientBuilder.AddHeaderPropagation();
         }
 
         extra?.Invoke(clientBuilder);

--- a/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
+++ b/Fhi.ClientCredentials.Refit/RefitClientCredentialsBuilder.cs
@@ -92,20 +92,14 @@ public class RefitClientCredentialsBuilder
             clientBuilder.RemoveAllLoggers();
         }
 
-        if (builderOptions.UseCorrelationId)
-        {
-            clientBuilder.AddHeaderPropagation();
-            // populate the HeaderPropagationValues dictionary so we can create the client regardless of being in or outside a HttpContext
-            clientBuilder.ConfigureHttpClient((sp, client) =>
-            {
-                var values = sp.GetRequiredService<HeaderPropagationValues>();
-                values.Headers = values.Headers ?? new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
-            });
-        }
-
         foreach (var type in DelegationHandlers)
         {
             clientBuilder.AddHttpMessageHandler((s) => (DelegatingHandler)s.GetRequiredService(type));
+        }
+
+        if (builderOptions.UseCorrelationId)
+        {
+            clientBuilder.AddHeaderPropagation();
         }
 
         extra?.Invoke(clientBuilder);

--- a/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
+++ b/Fhi.ClientCredentials.Refit/WebApplicationBuilderExtensions.cs
@@ -43,7 +43,6 @@ namespace Fhi.ClientCredentials.Refit
             if (options.UseCorrelationId)
             {
                 app.UseMiddleware<CorrelationIdMiddleware>();
-                app.UseHeaderPropagation();
             }
 
             return app;


### PR DESCRIPTION
As the CorrelationIdHandler handles propagating the correlation id header from the HttpContext to the Request, we do not need to add headerPropagation